### PR TITLE
PLT-7638: Sync on demand

### DIFF
--- a/src/Marlowe/Runtime/Web/Streaming.purs
+++ b/src/Marlowe/Runtime/Web/Streaming.purs
@@ -239,6 +239,10 @@ fetchContractTransactions contractId transactionEndpoint prevTransactions listen
       { contractTransactions: newTransactions
       , notify: Subscription.notify listener (contractId /\ change)
       }
+    Just (Nothing /\ newTransactions) -> pure $ Just
+      { contractTransactions: newTransactions
+      , notify: pure unit
+      }
     _ -> pure Nothing
 
 fetchContractsTransactions
@@ -352,6 +356,10 @@ fetchContractState contractId endpoint oldContractState listener serverUrl = do
     Just (Just change /\ newState) -> pure $ Just
       { contractState: newState
       , notify: Subscription.notify listener (contractId /\ change)
+      }
+    Just (Nothing /\ newState) -> pure $ Just
+      { contractState: newState
+      , notify: pure unit
       }
     _ -> pure Nothing
 


### PR DESCRIPTION
Added `sync` to the API to allow to refresh the state of a given contract on demand.